### PR TITLE
Fix error on empty commented line 

### DIFF
--- a/src/ini.zig
+++ b/src/ini.zig
@@ -247,7 +247,7 @@ fn consume(data: []const u8, seek: *usize, state: *TokenizerState) ?Token {
 }
 
 test "parse into map" {
-    var file = try std.fs.cwd().openFile("src/test.ini", .{ .read = true, .write = false });
+    var file = try std.fs.cwd().openFile("src/test.ini", .{ .mode = .read_only });
     defer file.close();
     var data = try std.testing.allocator.alloc(u8, try file.getEndPos());
     defer std.testing.allocator.free(data);
@@ -266,7 +266,7 @@ test "parse into map" {
 }
 
 test "parse into struct" {
-    var file = try std.fs.cwd().openFile("src/test.ini", .{ .read = true, .write = false });
+    var file = try std.fs.cwd().openFile("src/test.ini", .{ .mode = .read_only });
     defer file.close();
     var data = try std.testing.allocator.alloc(u8, try file.getEndPos());
     defer std.testing.allocator.free(data);

--- a/src/ini.zig
+++ b/src/ini.zig
@@ -196,7 +196,7 @@ fn consume(data: []const u8, seek: *usize, state: *TokenizerState) ?Token {
                         state.* = .nil;
                         return Token{
                             .kind = .comment,
-                            .value = data[start .. end - 2],
+                            .value = data[start .. std.math.max(start, end - 2)],
                         };
                     },
                     else => {},

--- a/src/test.ini
+++ b/src/test.ini
@@ -1,4 +1,5 @@
 ; last modified 1 April 2001 by John Doe
+;
 [owner]
 name = John Doe ; Comment
 organization = Acme Widgets Inc.


### PR DESCRIPTION
Hi, the lib panics when it encounters a line containing only a comment symbol (see example in this PR test.ini) with:
```
./src/ini.zig:199:42: error: out of bounds slice
                            .value = data[start .. end - 2],
                                         ^
./src/ini.zig:58:19: note: called from here
    while (consume(data[0..], &seek, &state)) |token| {
                  ^
./src/ini.zig:314:31: note: called from here
        var config = try parse(Config, data);
                              ^
./src/ini.zig:298:38: note: called from here
test "parse in comptime into struct" {
                                     ^
error: test...
error: The following command exited with error code 1:
```

here is my try to fix it.
Tell me what you think and thank you for having written this lib when you used to have time to write zig ;)
